### PR TITLE
[improve][sec] Bump Alluxio to 2.9.3

### DIFF
--- a/pulsar-io/alluxio/pom.xml
+++ b/pulsar-io/alluxio/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <properties>
-        <alluxio.version>2.7.3</alluxio.version>
+        <alluxio.version>2.9.3</alluxio.version>
         <metrics.version>4.1.11</metrics.version>
         <grpc.version>1.37.0</grpc.version>
     </properties>


### PR DESCRIPTION
### Motivation
Bump alluxio version to avoid [CVE-2023-38889](https://nvd.nist.gov/vuln/detail/CVE-2023-38889)



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

